### PR TITLE
fix: ArrayIndexOutOfBoundsException

### DIFF
--- a/src/generadordni/DNI.java
+++ b/src/generadordni/DNI.java
@@ -150,7 +150,7 @@ public class DNI {
      */
     public static int generaNumeroAleatorio(int minimo, int maximo){
         
-        int num=(int)Math.floor(Math.random()*(minimo-(maximo+1))+(maximo+1));
+        int num=(int)Math.floor(Math.random()*(minimo-maximo)+(maximo));             
         return num;
     }
     


### PR DESCRIPTION
Se soluciona la excepción tipo java.lang.ArrayIndexOutOfBoundsException que ocurría a veces calculando CIFs. Se ha modificado la función generaNumeroAleatorio() que daba un número igual al máximo y no debía.

Soluciona el fallo: #1 